### PR TITLE
Make send variable local instead of global

### DIFF
--- a/q-comm.js
+++ b/q-comm.js
@@ -1,4 +1,3 @@
-
 var Q = require("q");
 var LruMap = require("collections/lru-map");
 var Queue = require("./lib/queue");
@@ -218,7 +217,7 @@ function Connection(connection, local, options) {
 // Coerces a Worker to a Connection
 // Idempotent: Passes Connections through unaltered
 function adapt(port, origin) {
-
+    var send;
     // Adapt the sender side
     // ---------------------
     if (port.postMessage) {


### PR DESCRIPTION
Without declaring a local send variable, a global one is is created, which is likely unintended, and also causes problems when creating multiple connections. This edit probably fixes the open issue from fabianonunes (#10).
