### PR TITLE
Fix for compatibility with Q 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-connection",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "An inter-worker asynchronous promise communication system.",
   "homepage": "http://github.com/kriskowal/q-connection/",
   "author": "Kris Kowal <kris@cixar.com> (http://github.com/kriskowal/)",
@@ -23,7 +23,7 @@
   ],
   "main": "q-connection.js",
   "dependencies": {
-    "q": "~0.8.11",
+    "q": "~0.9.2",
     "collections": "~0.0.0"
   },
   "devDependencies": {

--- a/q-connection.js
+++ b/q-connection.js
@@ -30,7 +30,7 @@ function Connection(connection, local, options) {
         debug.apply(null, [debugKey].concat(Array.prototype.slice.call(arguments)));
     }
 
-    // message reciever loop
+    // message receiver loop
     Q.when(connection.get(), get).done();
     function get(message) {
         _debug("receive:", message);
@@ -41,6 +41,8 @@ function Connection(connection, local, options) {
     // message receiver
     function receive(message) {
         message = JSON.parse(message);
+        _debug("receive: parsed message", message);
+ 
         if (!receivers[message.type])
             return; // ignore bad message types
         if (!locals.has(message.to))
@@ -137,7 +139,10 @@ function Connection(connection, local, options) {
             var localId = makeId();
             var response = makeLocal(localId);
             var args = Array.prototype.slice.call(arguments, 1);
-            _debug('sending:', "R" + JSON.stringify(id), JSON.stringify(op), JSON.stringify(encode(args)));
+            if (Array.isArray(args[0])) {
+                args = args[0];
+            }
+             _debug('sending:', "R" + JSON.stringify(id), JSON.stringify(op), JSON.stringify(encode(args)));
             connection.put(JSON.stringify({
                 "type": "send",
                 "to": id,

--- a/test/atoms.js
+++ b/test/atoms.js
@@ -32,10 +32,10 @@ exports['test get atom'] = function (assert, done) {
     });
 }
 
-exports['test put atom'] = function (assert, done) {
+exports['test set atom'] = function (assert, done) {
     var peers = utils.createPeers({});
 
-    Q.when(Q.put(peers.remote, 'foo', 'bar'), function(value) {
+    Q.when(Q.set(peers.remote, 'foo', 'bar'), function(value) {
         assert.equal(peers.object.foo, 'bar', 'value of target has changed');
     });
     Q.when(Q.get(peers.remote, 'foo'), function(value) {


### PR DESCRIPTION
This address the issue of the double wrapping of the arguments
and a minor issue in the test
