### PR TITLE
Encode non literals as remote objects

### DIFF
--- a/q-connection.js
+++ b/q-connection.js
@@ -172,7 +172,7 @@ function Connection(connection, local, options) {
     // a utility for resolving the local promise
     // for a given identifier.
     function dispatchLocal(id, op, value) {
-        _debug(op + ':', "L" + JSON.stringify(id), JSON.stringify(value), typeof value);
+//        _debug(op + ':', "L" + JSON.stringify(id), JSON.stringify(value), typeof value);
         locals.get(id)[op](value);
     }
 


### PR DESCRIPTION
Submitting for review, specs to follow.

This means that the local object does not need to make any special accommodations for q-connection. The other side of the connection can invoke any method. This is especially useful when returning an array of objects since before they would have needed to be manually wrapped in a promise.
