### PR TITLE
Handle Chrome extension Port object

### DIFF
--- a/adapt.js
+++ b/adapt.js
@@ -50,6 +50,11 @@ function adapt(port, origin) {
         port.on("message", function (data) {
             queue.put(data);
         }, false);
+    // Chrome extension message ports
+    } else if (port.onMessage) {
+        port.onMessage.addListener(function (message) {
+            queue.put(message);
+        });
     } else if (port.addEventListener) {
         port.addEventListener("message", function (event) {
             queue.put(event.data);


### PR DESCRIPTION
As described here the api is of ports within an extension is onMessage.addListener and while it does respond to addEventListener, 
mixed usage is problematic since the listener set by addEventListener is overwritten.
http://developer.chrome.com/extensions/runtime.html#type-Port
