### PR TITLE
Add a sanitizeError option and specs

### DIFF
--- a/q-connection.js
+++ b/q-connection.js
@@ -23,6 +23,7 @@ function Connection(connection, local, options) {
     var makeId = options.makeId || function () {
         return UUID.generate();
     };
+    var sanitizeError = typeof options.sanitizeError === "function" ? options.sanitizeError : false;
     var locals = LruMap(null, options.max || Infinity);
     connection = adapt(connection, options.origin);
 
@@ -243,6 +244,9 @@ function Connection(connection, local, options) {
             ) {
                 var result = {};
                 if (object instanceof Error) {
+                    if (sanitizeError) {
+                        object = sanitizeError(object);
+                    }
                     result.message = object.message;
                     result.stack = object.stack;
                 }

--- a/spec/q-connection-spec.js
+++ b/spec/q-connection-spec.js
@@ -27,11 +27,11 @@ function makeChannel() {
     };
 }
 
-function makePeers(local, remote) {
+function makePeers(local, remote, options) {
     var channel = makeChannel();
     return {
-        local: Connection(channel.l2r, local),
-        remote: Connection(channel.r2l, remote),
+        local: Connection(channel.l2r, local, options),
+        remote: Connection(channel.r2l, remote, options),
         close: channel.close
     }
 }
@@ -380,3 +380,47 @@ describe("serialization", function () {
 
 });
 
+describe("options", function () {
+    describe("sanitizeError", function () {
+        var peers, options;
+        beforeEach(function () {
+            options = {
+                sanitizeError: function (error) {
+                    return {sanitized: true};
+                }
+            };
+            spyOn(options, "sanitizeError").andCallThrough();
+            peers = makePeers({
+                object: function () {
+                    return {object: true};
+                },
+                error: function () {
+                    return new Error("error");
+                }
+            }, null, options);
+        });
+
+        it("should be called with the error", function () {
+            return peers.remote.invoke("error")
+            .then(function (response) {
+                expect(options.sanitizeError).toHaveBeenCalled();
+                expect(options.sanitizeError.mostRecentCall.args[0].message).toEqual("error");
+            });
+        });
+
+        it("'s return value should be used instead of the error", function () {
+            return peers.remote.invoke("error")
+            .then(function (response) {
+                expect(response).toEqual({sanitized: true});
+            });
+        });
+
+        it("is not called for plain objects", function () {
+            return peers.remote.invoke("object")
+            .then(function (response) {
+                expect(response).toEqual({object: true});
+                expect(options.sanitizeError).not.toHaveBeenCalled();
+            });
+        });
+    });
+});


### PR DESCRIPTION
:warning: First pass at this idea. Happy to have a discussion about it. Also, the readme should be updated, but I didn't want to put that effort in until the approach has been approved.

Error objects often contain information, such as the stack, that should not be exposed to the client.

This adds the ability to give a `sanitizeError` function to the Connection that will be called whenever an Error is encoded. The return value of this function is used in place of the original error.
